### PR TITLE
 Enable dock-floating with title bars

### DIFF
--- a/src/editors/DockWindow.cpp
+++ b/src/editors/DockWindow.cpp
@@ -164,10 +164,7 @@ void DockWindow::onDockTopLevelChanged(bool floating)
 
 void DockWindow::setDockTitleBar(QDockWidget *dock)
 {
-    if (dock->isFloating()) {
-        delete dock->titleBarWidget();
-        dock->setTitleBarWidget(nullptr);
-    } else if (!dock->titleBarWidget()) {
+    if (!dock->titleBarWidget()) {
         auto title = new DockTitle(dock);
         dock->setTitleBarWidget(title);
 

--- a/src/windows/MainWindow.cpp
+++ b/src/windows/MainWindow.cpp
@@ -133,7 +133,7 @@ MainWindow::MainWindow(QWidget *parent)
     dock->setObjectName("Session");
     dock->setTitleBarWidget(new WindowTitle(dock));
     dock->setFeatures(QDockWidget::DockWidgetClosable
-        | QDockWidget::DockWidgetMovable);
+        | QDockWidget::DockWidgetMovable | QDockWidget::DockWidgetFloatable);
     dock->setWidget(mSessionSplitter);
     dock->setVisible(false);
     dock->setMinimumSize(200, 150);
@@ -151,7 +151,7 @@ MainWindow::MainWindow(QWidget *parent)
     dock->setObjectName("FileBrowser");
     dock->setTitleBarWidget(mFileBrowserWindow->titleBar());
     dock->setFeatures(QDockWidget::DockWidgetClosable
-        | QDockWidget::DockWidgetMovable);
+        | QDockWidget::DockWidgetMovable | QDockWidget::DockWidgetFloatable);
     dock->setWidget(mFileBrowserWindow.get());
     dock->setVisible(false);
     dock->setMinimumSize(150, 150);
@@ -167,7 +167,7 @@ MainWindow::MainWindow(QWidget *parent)
     dock->setObjectName("Messages");
     dock->setTitleBarWidget(new WindowTitle(dock));
     dock->setFeatures(QDockWidget::DockWidgetClosable
-        | QDockWidget::DockWidgetMovable);
+        | QDockWidget::DockWidgetMovable | QDockWidget::DockWidgetFloatable);
     dock->setWidget(mMessageWindow.get());
     dock->setVisible(false);
     dock->setMinimumSize(150, 150);
@@ -183,7 +183,7 @@ MainWindow::MainWindow(QWidget *parent)
     dock->setObjectName("Output");
     dock->setTitleBarWidget(mOutputWindow->titleBar());
     dock->setFeatures(QDockWidget::DockWidgetClosable
-        | QDockWidget::DockWidgetMovable);
+        | QDockWidget::DockWidgetMovable | QDockWidget::DockWidgetFloatable);
     dock->setWidget(mOutputWindow.get());
     dock->setVisible(false);
     dock->setMinimumSize(150, 150);


### PR DESCRIPTION
Enable `DockWidgetFloatable` on all docks.
Keep dock title/caption bars when floating so drag-to-redock works.

Without this patch, when dragging any tile/window outside the docking canvas and leaving it there, the title/caption bar is lost and there is no way to restart dragging.
The window remains as a raw floating frame.
